### PR TITLE
Adjust initial camera pitch

### DIFF
--- a/src/components/xz-orbit-controls.tsx
+++ b/src/components/xz-orbit-controls.tsx
@@ -18,13 +18,20 @@ export function XZOrbitControls({
   zoomSpeed = 0.1,
 }: XZOrbitControlsProps) {
   const { camera, gl } = useThree()
-  const angles = useRef({ theta: Math.PI / 4, phi: 0 })
+  const angles = useRef({ theta: Math.PI / 4, phi: Math.PI / 4 })
   const radius = useRef(distance)
   const isDragging = useRef(false)
   const pointer = useRef({ x: 0, y: 0 })
 
   useEffect(() => {
     camera.up.set(0, 0, 1)
+    const r = radius.current
+    const { theta, phi } = angles.current
+    const x = r * Math.cos(theta) * Math.cos(phi)
+    const y = r * Math.sin(theta) * Math.cos(phi)
+    const z = r * Math.sin(phi)
+    camera.position.set(x, y, z)
+    camera.lookAt(new THREE.Vector3(0, 0, 0))
     const element = gl.domElement
 
     const onPointerDown = (e: PointerEvent) => {


### PR DESCRIPTION
## Summary
- set the orbit control start angle 45° above the horizon
- ensure the camera is positioned and oriented at mount

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c3174510c832390223b94ee5b774e