### PR TITLE
Add color chooser for Wave Planter

### DIFF
--- a/src/layouts/modelLayout.tsx
+++ b/src/layouts/modelLayout.tsx
@@ -24,6 +24,7 @@ export interface ModelLayoutProps<T extends Record<string, number>> {
     props?: T
     meshRef?: React.RefObject<THREE.Mesh>
   }>
+  children?: React.ReactNode
 }
 
 export default function ModelLayout<T extends Record<string, number>>({
@@ -33,6 +34,7 @@ export default function ModelLayout<T extends Record<string, number>>({
   camera = [4, 4, 4],
   orbitDistance = 7,
   mesh,
+  children,
 }: ModelLayoutProps<T>) {
   const [values, setValues] = React.useState<T>(defaultValues)
   const meshRef = React.useRef<THREE.Mesh>(null!)
@@ -60,6 +62,7 @@ export default function ModelLayout<T extends Record<string, number>>({
                 onChange={handlePropUpdate}
                 ranges={ranges}
               />
+              {children}
               <Button onClick={exportModel} className="mt-4 w-full">
                 Export as .stl file
               </Button>

--- a/src/models/waveplanter.tsx
+++ b/src/models/waveplanter.tsx
@@ -24,9 +24,11 @@ export const DEFAULT_PROPS: WavePlanterProps = {
 export function WavePlanterMesh({
   props = DEFAULT_PROPS,
   meshRef,
+  color = "#AAAAAA",
 }: {
   props?: WavePlanterProps;
   meshRef?: React.RefObject<THREE.Mesh>;
+  color?: string;
 }) {
   const RingGear = ({
     R,
@@ -97,7 +99,7 @@ export function WavePlanterMesh({
         {!material && (
           <meshStandardMaterial
             attach="material"
-            color="#7F8CAA"
+            color={color}
             side={THREE.DoubleSide}
           />
         )}
@@ -118,13 +120,14 @@ export function WavePlanterMesh({
         castShadow
         receiveShadow
       />
-      <meshStandardMaterial color="#AAAAAA" />
+      <meshStandardMaterial color={color} />
     </mesh>
   );
 }
 
 export default function WavePlanterModel() {
-  const meshElement = <WavePlanterMesh />;
+  const [color, setColor] = React.useState("#AAAAAA");
+  const meshElement = <WavePlanterMesh color={color} />;
   return (
     <ModelLayout
       name={MODEL_NAME}
@@ -139,6 +142,16 @@ export default function WavePlanterModel() {
         twistWaves: { min: 0, max: 1, step: 0.01 },
       }}
       mesh={meshElement}
-    />
+    >
+      <label className="flex flex-col gap-1 mb-4 text-sm">
+        <span className="capitalize mb-1 flex justify-between">Color</span>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-8 w-full p-0 border-none bg-transparent"
+        />
+      </label>
+    </ModelLayout>
   );
 }


### PR DESCRIPTION
## Summary
- allow injecting custom controls into `ModelLayout`
- update Wave Planter model with a color chooser

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dc99b14a88323b2a30dfc0ec892c9