### PR TITLE
Add cylinder to wave planter model

### DIFF
--- a/src/models/waveplanter.tsx
+++ b/src/models/waveplanter.tsx
@@ -125,7 +125,7 @@ export function WavePlanterMesh({
         castShadow
         receiveShadow
       >
-        <cylinderGeometry args={[props.radius, props.radius, 8, 64]} />
+        <cylinderGeometry args={[props.radius - 4, props.radius - 4, 4, 128]} />
         <meshStandardMaterial color={color} />
       </mesh>
       <meshStandardMaterial color={color} />


### PR DESCRIPTION
## Summary
- add a cylinder mesh to the WavePlanter model

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dce5c21c4832399088d44c3d6f4cc