### PR TITLE
Improve STL export

### DIFF
--- a/src/hooks/use-stl-export.ts
+++ b/src/hooks/use-stl-export.ts
@@ -29,11 +29,16 @@ export function useStlExport<T extends THREE.Object3D>(
     const root = ref.current;
     root.updateMatrixWorld(true);
 
-    const groups = root.children.filter(
+    const explicit = [
+      root.getObjectByName("waveplanter"),
+      root.getObjectByName("baseplanter"),
+    ].filter((o): o is THREE.Object3D => o !== null);
+
+    const children = root.children.filter(
       (c): c is THREE.Object3D & { name: string } => c.name !== ""
     );
 
-    const targets = groups.length > 0 ? groups : [root];
+    const targets = explicit.length > 0 ? explicit : children.length > 0 ? children : [root];
 
     targets.forEach((obj) => {
       const geom = mergeGroup(obj);


### PR DESCRIPTION
## Summary
- export each subgroup as its own STL
- merge child meshes before export so STL files aren't decoupled

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ec8a6a0f883238fc3e50f83139473