### PR TITLE
Add separate export buttons for waveplanter

### DIFF
--- a/src/layouts/modelLayout.tsx
+++ b/src/layouts/modelLayout.tsx
@@ -25,6 +25,14 @@ export interface ModelLayoutProps<T extends Record<string, number>> {
     meshRef?: React.RefObject<THREE.Group>
   }>
   children?: React.ReactNode
+  /**
+   * Optional render function to customize export controls.
+   * Receives the default export handler and the mesh reference.
+   */
+  renderExport?: (args: {
+    exportModel: () => void
+    meshRef: React.RefObject<THREE.Group>
+  }) => React.ReactNode
 }
 
 export default function ModelLayout<T extends Record<string, number>>({
@@ -35,6 +43,7 @@ export default function ModelLayout<T extends Record<string, number>>({
   orbitDistance = 7,
   mesh,
   children,
+  renderExport,
 }: ModelLayoutProps<T>) {
   const [values, setValues] = React.useState<T>(defaultValues)
   const meshRef = React.useRef<THREE.Group>(null!)
@@ -63,9 +72,13 @@ export default function ModelLayout<T extends Record<string, number>>({
                 ranges={ranges}
               />
               {children}
-              <Button onClick={exportModel} className="mt-4 w-full">
-                Export as .stl file
-              </Button>
+              {renderExport ? (
+                renderExport({ exportModel, meshRef })
+              ) : (
+                <Button onClick={exportModel} className="mt-4 w-full">
+                  Export as .stl file
+                </Button>
+              )}
             </SidebarContent>
           </Sidebar>
           <div className="flex-1 relative">

--- a/src/models/waveplanter.tsx
+++ b/src/models/waveplanter.tsx
@@ -3,6 +3,8 @@ import * as THREE from "three";
 import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { type ThreeElements } from "@react-three/fiber";
 import ModelLayout from "@/layouts/modelLayout";
+import { STLExporter } from "three-stdlib";
+import { Button } from "@/components/ui/button";
 
 export interface WavePlanterProps extends Record<string, number> {
   radius: number;
@@ -278,6 +280,35 @@ export function WavePlanterMesh({
 export default function WavePlanterModel() {
   const [color, setColor] = React.useState("#AAAAAA");
   const meshElement = <WavePlanterMesh color={color} />;
+  const renderExport = React.useCallback(
+    ({ meshRef }: { exportModel: () => void; meshRef: React.RefObject<THREE.Group> }) => {
+      const exportByName = (groupName: string, fileName: string) => {
+        const obj = meshRef.current?.getObjectByName(groupName);
+        if (!obj) return;
+        const exporter = new STLExporter();
+        const stl = exporter.parse(obj, { binary: true });
+        const blob = new Blob([stl], { type: "model/stl" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${fileName}.stl`;
+        link.click();
+        URL.revokeObjectURL(url);
+      };
+
+      return (
+        <div className="flex flex-col gap-2 mt-4">
+          <Button onClick={() => exportByName("waveplanter", "waveplanter")} className="w-full">
+            Export waveplanter
+          </Button>
+          <Button onClick={() => exportByName("baseplanter", "baseplanter")} className="w-full">
+            Export baseplanter
+          </Button>
+        </div>
+      );
+    },
+    []
+  );
   return (
     <ModelLayout
       name={MODEL_NAME}
@@ -293,6 +324,7 @@ export default function WavePlanterModel() {
         twistWaves: { min: 0, max: 1, step: 0.01 },
       }}
       mesh={meshElement}
+      renderExport={renderExport}
     >
       <label className="flex flex-col gap-1 mb-4 text-sm">
         <span className="capitalize mb-1 flex justify-between">Color</span>


### PR DESCRIPTION
## Summary
- allow custom export actions in `ModelLayout`
- add two export buttons for WavePlanter

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ecd1704348323afe2a851c09fa7d4