### PR TITLE
Optimize hydration for better load times

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import AppLayout from "@/layouts/appLayout";
     <title>Tools</title>
   </head>
   <body>
-    <AppLayout client:load>
+    <AppLayout client:idle>
       <p>Home page</p>
     </AppLayout>
   </body>

--- a/src/pages/planter/wave.astro
+++ b/src/pages/planter/wave.astro
@@ -10,6 +10,6 @@ import WavePlanterModel from "@/models/waveplanter";
     <title>Wave Planter</title>
   </head>
   <body>
-    <WavePlanterModel client:load />
+    <WavePlanterModel client:visible />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- switch AppLayout to `client:idle`
- hydrate the WavePlanter model only when visible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685481b7feec83238666bd5d7d411092