### PR TITLE
Fix STL export to skip hidden CSG operations

### DIFF
--- a/src/models/waveplanter.tsx
+++ b/src/models/waveplanter.tsx
@@ -418,9 +418,11 @@ export default function WavePlanterModel() {
         const obj = meshRef.current?.getObjectByName(groupName)
         if (!obj) return
         const clone = obj.clone(true)
+        const toRemove: THREE.Object3D[] = []
         clone.traverse((child) => {
-          if (!child.visible) child.parent?.remove(child)
+          if (!child.visible) toRemove.push(child)
         })
+        toRemove.forEach((child) => child.parent?.remove(child))
         const exporter = new STLExporter()
         const stl = exporter.parse(clone, { binary: true })
         const blob = new Blob([stl], { type: "model/stl" });


### PR DESCRIPTION
## Summary
- clone baseplanter group and remove invisible CSG objects before exporting

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855092500dc8323988dd8e4639618b7