### PR TITLE
Use three-csg-ts for model boolean operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@react-three/drei": "^10.3.0",
-        "@react-three/fiber": "^9.1.4",
+        "@react-three/drei": "^10.5.0",
+        "@react-three/fiber": "^9.2.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/react-dom": "^19.1.6",
-        "astro": "^5.10.1",
+        "astro": "^5.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
@@ -28,9 +28,9 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "three": "^0.177.0",
-        "three-bvh-csg": "^0.0.17",
+        "three-csg-ts": "^3.2.0",
         "three-stdlib": "^2.36.0",
-        "tw-animate-css": "^1.3.4"
+        "tw-animate-css": "^1.3.5"
       },
       "devDependencies": {
         "@types/react": "^19.1.8",
@@ -2051,16 +2051,16 @@
       "license": "MIT"
     },
     "node_modules/@react-three/drei": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.3.0.tgz",
-      "integrity": "sha512-+4NHCAUI38jp8XlbuKKWl/23y3F/JKdkvnYsrVXxhw150OyWKJoft+Yyd7dl6awxfV/Gn08x3R9pRRFUuDQwDA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.5.0.tgz",
+      "integrity": "sha512-8VHFmwiIixw0MhTt8ZiLPZH/JrJVsRQiosHqBrV2qRKhYB4aPJ1A9MkqQdKnxUfvvbsi0zu2iXeRCH1HhUaNsg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mediapipe/tasks-vision": "0.10.17",
         "@monogrid/gainmap-js": "^3.0.6",
         "@use-gesture/react": "^10.3.1",
-        "camera-controls": "^2.9.0",
+        "camera-controls": "^3.0.0",
         "cross-env": "^7.0.3",
         "detect-gpu": "^5.0.56",
         "glsl-noise": "^0.0.0",
@@ -2091,9 +2091,9 @@
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.1.4.tgz",
-      "integrity": "sha512-Ugzs6n6YNORSa4hRZH1CKTd5DLTzwOvYjze+EZWS8iVDyeNQETnLzuke+MMEuXTqM8eAV/gyWgd27t/GR41oGA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.2.0.tgz",
+      "integrity": "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -3168,9 +3168,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.10.1.tgz",
-      "integrity": "sha512-DJVmt+51jU1xmgmAHCDwuUgcG/5aVFSU+tcX694acAZqPVt8EMUAmUZcJDX36Z7/EztnPph9HR3pm72jS2EgHQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.11.1.tgz",
+      "integrity": "sha512-32dpUh0tXSV/FR2q2/z7LOA6IXl7RqET9J51IA0pPSSi3exhRP3EOSQGjBq10DzXT7VrvplDrFqwfiiWBS8oYA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
@@ -3425,10 +3425,14 @@
       }
     },
     "node_modules/camera-controls": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
-      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
+      "integrity": "sha512-w5oULNpijgTRH0ARFJJ0R5ct1nUM3R3WP7/b8A6j9uTGpRfnsypc/RBMPQV8JQDPayUe37p/TZZY1PcUr4czOQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0",
+        "npm": ">=10.8.2"
+      },
       "peerDependencies": {
         "three": ">=0.126.1"
       }
@@ -6766,14 +6770,14 @@
       "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
       "license": "MIT"
     },
-    "node_modules/three-bvh-csg": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/three-bvh-csg/-/three-bvh-csg-0.0.17.tgz",
-      "integrity": "sha512-iEkHDF8GRfGM6593Cuw8SnF1vfENCp46gIAtRzuL4nGXGWPcR1sbTBwM9ptDONb5twqlZp5WkAKya5aBKe2qcA==",
+    "node_modules/three-csg-ts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/three-csg-ts/-/three-csg-ts-3.2.0.tgz",
+      "integrity": "sha512-oTYg8kdal6qgHDbso/6VzA12Udf2ic2uXhf0XlJzuSP+Gs0OUR5gTHSZ7GotAE+M/QcVlw41eOwiWZVnJG5/8w==",
       "license": "MIT",
       "peerDependencies": {
-        "three": ">=0.151.0",
-        "three-mesh-bvh": ">=0.6.6"
+        "@types/three": ">= 0.154.0",
+        "three": ">= 0.154.0"
       }
     },
     "node_modules/three-mesh-bvh": {
@@ -6956,9 +6960,9 @@
       }
     },
     "node_modules/tw-animate-css": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.4.tgz",
-      "integrity": "sha512-dd1Ht6/YQHcNbq0znIT6dG8uhO7Ce+VIIhZUhjsryXsMPJQz3bZg7Q2eNzLwipb25bRZslGb2myio5mScd1TFg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.5.tgz",
+      "integrity": "sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
     "three": "^0.177.0",
-    "three-bvh-csg": "^0.0.17",
+    "three-csg-ts": "^3.2.0",
     "three-stdlib": "^2.36.0",
     "tw-animate-css": "^1.3.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       three:
         specifier: ^0.177.0
         version: 0.177.0
-      three-bvh-csg:
-        specifier: ^0.0.17
-        version: 0.0.17(three-mesh-bvh@0.8.3(three@0.177.0))(three@0.177.0)
+      three-csg-ts:
+        specifier: ^3.2.0
+        version: 3.2.0(@types/three@0.177.0)(three@0.177.0)
       three-stdlib:
         specifier: ^2.36.0
         version: 2.36.0(three@0.177.0)
@@ -2260,11 +2260,11 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
 
-  three-bvh-csg@0.0.17:
-    resolution: {integrity: sha512-iEkHDF8GRfGM6593Cuw8SnF1vfENCp46gIAtRzuL4nGXGWPcR1sbTBwM9ptDONb5twqlZp5WkAKya5aBKe2qcA==}
+  three-csg-ts@3.2.0:
+    resolution: {integrity: sha512-oTYg8kdal6qgHDbso/6VzA12Udf2ic2uXhf0XlJzuSP+Gs0OUR5gTHSZ7GotAE+M/QcVlw41eOwiWZVnJG5/8w==}
     peerDependencies:
-      three: '>=0.151.0'
-      three-mesh-bvh: '>=0.6.6'
+      '@types/three': '>= 0.154.0'
+      three: '>= 0.154.0'
 
   three-mesh-bvh@0.8.3:
     resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
@@ -5086,10 +5086,10 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  three-bvh-csg@0.0.17(three-mesh-bvh@0.8.3(three@0.177.0))(three@0.177.0):
+  three-csg-ts@3.2.0(@types/three@0.177.0)(three@0.177.0):
     dependencies:
+      '@types/three': 0.177.0
       three: 0.177.0
-      three-mesh-bvh: 0.8.3(three@0.177.0)
 
   three-mesh-bvh@0.8.3(three@0.177.0):
     dependencies:

--- a/src/models/wavy/bottom.tsx
+++ b/src/models/wavy/bottom.tsx
@@ -6,7 +6,7 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import * as React from "react";
 import * as THREE from "three";
-import { ADDITION, Brush, Evaluator, SUBTRACTION } from "three-bvh-csg";
+import { CSG } from "three-csg-ts";
 import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { Button } from "@/components/ui/button";
 import { wavyProperties, type WavyProperties } from "@/utils/properties";
@@ -91,32 +91,36 @@ export default function WavyBottom() {
 
 function getBottomGeometry(radius: number, waveDensity: number, height: number, twistRatio: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
     const bodyGeometry = createWavyGeometry(radius, 0.4, waveDensity, height, .1 * twistRatio, 1024, true);
-    const bodyBrush = new Brush(bodyGeometry);
+    const bodyMesh = new THREE.Mesh(bodyGeometry);
+    bodyMesh.updateMatrix();
 
     const floorGeometry = new THREE.CylinderGeometry(radius - 3, radius - 3, 4, 32);
     floorGeometry.translate(0, 2, 0);
-    const floorBrush = new Brush(floorGeometry);
+    const floorMesh = new THREE.Mesh(floorGeometry);
+    floorMesh.updateMatrix();
 
     const waterHoleGeometry = new THREE.BoxGeometry(20, 10, 20);
     waterHoleGeometry.translate(radius - 5, height, 0);
-    const waterHoleBrush = new Brush(waterHoleGeometry);
+    const waterHoleMesh = new THREE.Mesh(waterHoleGeometry);
+    waterHoleMesh.updateMatrix();
 
     const waterEntryGeometry = new THREE.BoxGeometry(25, 7.5, 25);
     waterEntryGeometry.translate(radius - 5, height - 3.7, 0);
-    const waterEntryBrush = new Brush(waterEntryGeometry);
+    const waterEntryMesh = new THREE.Mesh(waterEntryGeometry);
+    waterEntryMesh.updateMatrix();
 
     const cylinderHoleGeometry = new THREE.CylinderGeometry(radius - 3, radius - 3, height, 32);
     cylinderHoleGeometry.translate(0, (height / 2) + 4, 0);
-    const cylinderHoleBrush = new Brush(cylinderHoleGeometry);
+    const cylinderHoleMesh = new THREE.Mesh(cylinderHoleGeometry);
+    cylinderHoleMesh.updateMatrix();
 
-    const evaluator = new Evaluator();
-    let result = evaluator.evaluate(bodyBrush, floorBrush, ADDITION);
-    result = evaluator.evaluate(result, waterEntryBrush, ADDITION);
-    result = evaluator.evaluate(result, waterHoleBrush, SUBTRACTION);
-    result = evaluator.evaluate(result, cylinderHoleBrush, SUBTRACTION);
-    result.geometry = mergeVertices(result.geometry, 1e-5);
-    result.geometry.deleteAttribute('normal');
-    result.geometry.computeVertexNormals();
+    let resultMesh = CSG.union(bodyMesh, floorMesh);
+    resultMesh = CSG.union(resultMesh, waterEntryMesh);
+    resultMesh = CSG.subtract(resultMesh, waterHoleMesh);
+    resultMesh = CSG.subtract(resultMesh, cylinderHoleMesh);
 
-    return result.geometry;
+    const geometry = mergeVertices(resultMesh.geometry as THREE.BufferGeometry, 1e-5);
+    geometry.computeVertexNormals();
+
+    return geometry;
 }


### PR DESCRIPTION
## Summary
- replace `three-bvh-csg` with `three-csg-ts`
- refactor wavy models to use new `CSG` API
- update dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687516cc8a788323ba09a903bdd50814