### PR TITLE
Switch to custom CSG implementation

### DIFF
--- a/lib/csg/CSG.ts
+++ b/lib/csg/CSG.ts
@@ -1,0 +1,241 @@
+import { BufferAttribute, BufferGeometry, Matrix3, Matrix4, Mesh, Vector3, } from 'three';
+import { NBuf2, NBuf3 } from './NBuf';
+import { Node } from './Node';
+import { Polygon } from './Polygon';
+import { Vector } from './Vector';
+import { Vertex } from './Vertex';
+/**
+ * Holds a binary space partition tree representing a 3D solid. Two solids can
+ * be combined using the `union()`, `subtract()`, and `intersect()` methods.
+ */
+export class CSG {
+    constructor() {
+        this.polygons = [];
+    }
+    static fromPolygons(polygons) {
+        const csg = new CSG();
+        csg.polygons = polygons;
+        return csg;
+    }
+    static fromGeometry(geom, objectIndex) {
+        let polys = [];
+        const posattr = geom.attributes.position;
+        const normalattr = geom.attributes.normal;
+        const uvattr = geom.attributes.uv;
+        const colorattr = geom.attributes.color;
+        const grps = geom.groups;
+        let index;
+        if (geom.index) {
+            index = geom.index.array;
+        }
+        else {
+            index = new Uint16Array((posattr.array.length / posattr.itemSize) | 0);
+            for (let i = 0; i < index.length; i++)
+                index[i] = i;
+        }
+        const triCount = (index.length / 3) | 0;
+        polys = new Array(triCount);
+        for (let i = 0, pli = 0, l = index.length; i < l; i += 3, pli++) {
+            const vertices = new Array(3);
+            for (let j = 0; j < 3; j++) {
+                const vi = index[i + j];
+                const vp = vi * 3;
+                const vt = vi * 2;
+                const x = posattr.array[vp];
+                const y = posattr.array[vp + 1];
+                const z = posattr.array[vp + 2];
+                const nx = normalattr.array[vp];
+                const ny = normalattr.array[vp + 1];
+                const nz = normalattr.array[vp + 2];
+                const u = uvattr === null || uvattr === void 0 ? void 0 : uvattr.array[vt];
+                const v = uvattr === null || uvattr === void 0 ? void 0 : uvattr.array[vt + 1];
+                vertices[j] = new Vertex(new Vector(x, y, z), new Vector(nx, ny, nz), new Vector(u, v, 0), colorattr &&
+                    new Vector(colorattr.array[vp], colorattr.array[vp + 1], colorattr.array[vp + 2]));
+            }
+            if (objectIndex === undefined && grps && grps.length > 0) {
+                for (const grp of grps) {
+                    if (i >= grp.start && i < grp.start + grp.count) {
+                        polys[pli] = new Polygon(vertices, grp.materialIndex);
+                    }
+                }
+            }
+            else {
+                polys[pli] = new Polygon(vertices, objectIndex);
+            }
+        }
+        return CSG.fromPolygons(polys.filter((p) => !Number.isNaN(p.plane.normal.x)));
+    }
+    static toGeometry(csg, toMatrix) {
+        let triCount = 0;
+        const ps = csg.polygons;
+        for (const p of ps) {
+            triCount += p.vertices.length - 2;
+        }
+        const geom = new BufferGeometry();
+        const vertices = new NBuf3(triCount * 3 * 3);
+        const normals = new NBuf3(triCount * 3 * 3);
+        const uvs = new NBuf2(triCount * 2 * 3);
+        let colors;
+        const grps = [];
+        const dgrp = [];
+        for (const p of ps) {
+            const pvs = p.vertices;
+            const pvlen = pvs.length;
+            if (p.shared !== undefined) {
+                if (!grps[p.shared])
+                    grps[p.shared] = [];
+            }
+            if (pvlen && pvs[0].color !== undefined) {
+                if (!colors)
+                    colors = new NBuf3(triCount * 3 * 3);
+            }
+            for (let j = 3; j <= pvlen; j++) {
+                const grp = p.shared === undefined ? dgrp : grps[p.shared];
+                grp.push(vertices.top / 3, vertices.top / 3 + 1, vertices.top / 3 + 2);
+                vertices.write(pvs[0].pos);
+                vertices.write(pvs[j - 2].pos);
+                vertices.write(pvs[j - 1].pos);
+                normals.write(pvs[0].normal);
+                normals.write(pvs[j - 2].normal);
+                normals.write(pvs[j - 1].normal);
+                if (uvs) {
+                    uvs.write(pvs[0].uv);
+                    uvs.write(pvs[j - 2].uv);
+                    uvs.write(pvs[j - 1].uv);
+                }
+                if (colors) {
+                    colors.write(pvs[0].color);
+                    colors.write(pvs[j - 2].color);
+                    colors.write(pvs[j - 1].color);
+                }
+            }
+        }
+        geom.setAttribute('position', new BufferAttribute(vertices.array, 3));
+        geom.setAttribute('normal', new BufferAttribute(normals.array, 3));
+        uvs && geom.setAttribute('uv', new BufferAttribute(uvs.array, 2));
+        colors && geom.setAttribute('color', new BufferAttribute(colors.array, 3));
+        for (let gi = 0; gi < grps.length; gi++) {
+            if (grps[gi] === undefined) {
+                grps[gi] = [];
+            }
+        }
+        if (grps.length) {
+            let index = [];
+            let gbase = 0;
+            for (let gi = 0; gi < grps.length; gi++) {
+                geom.addGroup(gbase, grps[gi].length, gi);
+                gbase += grps[gi].length;
+                index = index.concat(grps[gi]);
+            }
+            geom.addGroup(gbase, dgrp.length, grps.length);
+            index = index.concat(dgrp);
+            geom.setIndex(index);
+        }
+        const inv = new Matrix4().copy(toMatrix).invert();
+        geom.applyMatrix4(inv);
+        geom.computeBoundingSphere();
+        geom.computeBoundingBox();
+        return geom;
+    }
+    static fromMesh(mesh, objectIndex) {
+        const csg = CSG.fromGeometry(mesh.geometry, objectIndex);
+        const ttvv0 = new Vector3();
+        const tmpm3 = new Matrix3();
+        tmpm3.getNormalMatrix(mesh.matrix);
+        for (let i = 0; i < csg.polygons.length; i++) {
+            const p = csg.polygons[i];
+            for (let j = 0; j < p.vertices.length; j++) {
+                const v = p.vertices[j];
+                v.pos.copy(ttvv0.copy(v.pos.toVector3()).applyMatrix4(mesh.matrix));
+                v.normal.copy(ttvv0.copy(v.normal.toVector3()).applyMatrix3(tmpm3));
+            }
+        }
+        return csg;
+    }
+    static toMesh(csg, toMatrix, toMaterial) {
+        const geom = CSG.toGeometry(csg, toMatrix);
+        const m = new Mesh(geom, toMaterial);
+        m.matrix.copy(toMatrix);
+        m.matrix.decompose(m.position, m.quaternion, m.scale);
+        m.rotation.setFromQuaternion(m.quaternion);
+        m.updateMatrixWorld();
+        m.castShadow = m.receiveShadow = true;
+        return m;
+    }
+    static union(meshA, meshB) {
+        const csgA = CSG.fromMesh(meshA);
+        const csgB = CSG.fromMesh(meshB);
+        return CSG.toMesh(csgA.union(csgB), meshA.matrix, meshA.material);
+    }
+    static subtract(meshA, meshB) {
+        const csgA = CSG.fromMesh(meshA);
+        const csgB = CSG.fromMesh(meshB);
+        return CSG.toMesh(csgA.subtract(csgB), meshA.matrix, meshA.material);
+    }
+    static intersect(meshA, meshB) {
+        const csgA = CSG.fromMesh(meshA);
+        const csgB = CSG.fromMesh(meshB);
+        return CSG.toMesh(csgA.intersect(csgB), meshA.matrix, meshA.material);
+    }
+    clone() {
+        const csg = new CSG();
+        csg.polygons = this.polygons
+            .map((p) => p.clone())
+            .filter((p) => Number.isFinite(p.plane.w));
+        return csg;
+    }
+    toPolygons() {
+        return this.polygons;
+    }
+    union(csg) {
+        const a = new Node(this.clone().polygons);
+        const b = new Node(csg.clone().polygons);
+        a.clipTo(b);
+        b.clipTo(a);
+        b.invert();
+        b.clipTo(a);
+        b.invert();
+        a.build(b.allPolygons());
+        return CSG.fromPolygons(a.allPolygons());
+    }
+    subtract(csg) {
+        const a = new Node(this.clone().polygons);
+        const b = new Node(csg.clone().polygons);
+        a.invert();
+        a.clipTo(b);
+        b.clipTo(a);
+        b.invert();
+        b.clipTo(a);
+        b.invert();
+        a.build(b.allPolygons());
+        a.invert();
+        return CSG.fromPolygons(a.allPolygons());
+    }
+    intersect(csg) {
+        const a = new Node(this.clone().polygons);
+        const b = new Node(csg.clone().polygons);
+        a.invert();
+        b.clipTo(a);
+        b.invert();
+        a.clipTo(b);
+        b.clipTo(a);
+        a.build(b.allPolygons());
+        a.invert();
+        return CSG.fromPolygons(a.allPolygons());
+    }
+    // Return a new CSG solid with solid and empty space switched. This solid is
+    // not modified.
+    inverse() {
+        const csg = this.clone();
+        for (const p of csg.polygons) {
+            p.flip();
+        }
+        return csg;
+    }
+    toMesh(toMatrix, toMaterial) {
+        return CSG.toMesh(this, toMatrix, toMaterial);
+    }
+    toGeometry(toMatrix) {
+        return CSG.toGeometry(this, toMatrix);
+    }
+}

--- a/lib/csg/NBuf.ts
+++ b/lib/csg/NBuf.ts
@@ -1,0 +1,21 @@
+export class NBuf3 {
+    constructor(ct) {
+        this.top = 0;
+        this.array = new Float32Array(ct);
+    }
+    write(v) {
+        this.array[this.top++] = v.x;
+        this.array[this.top++] = v.y;
+        this.array[this.top++] = v.z;
+    }
+}
+export class NBuf2 {
+    constructor(ct) {
+        this.top = 0;
+        this.array = new Float32Array(ct);
+    }
+    write(v) {
+        this.array[this.top++] = v.x;
+        this.array[this.top++] = v.y;
+    }
+}

--- a/lib/csg/Node.ts
+++ b/lib/csg/Node.ts
@@ -1,0 +1,92 @@
+/**
+ * Holds a node in a BSP tree. A BSP tree is built from a collection of polygons
+ * by picking a polygon to split along. That polygon (and all other coplanar
+ * polygons) are added directly to that node and the other polygons are added to
+ * the front and/or back subtrees. This is not a leafy BSP tree since there is
+ * no distinction between internal and leaf nodes.
+ */
+export class Node {
+    constructor(polygons) {
+        this.plane = null;
+        this.front = null;
+        this.back = null;
+        this.polygons = [];
+        if (polygons)
+            this.build(polygons);
+    }
+    clone() {
+        const node = new Node();
+        node.plane = this.plane && this.plane.clone();
+        node.front = this.front && this.front.clone();
+        node.back = this.back && this.back.clone();
+        node.polygons = this.polygons.map((p) => p.clone());
+        return node;
+    }
+    // Convert solid space to empty space and empty space to solid space.
+    invert() {
+        for (let i = 0; i < this.polygons.length; i++)
+            this.polygons[i].flip();
+        this.plane && this.plane.flip();
+        this.front && this.front.invert();
+        this.back && this.back.invert();
+        const temp = this.front;
+        this.front = this.back;
+        this.back = temp;
+    }
+    // Recursively remove all polygons in `polygons` that are inside this BSP
+    // tree.
+    clipPolygons(polygons) {
+        if (!this.plane)
+            return polygons.slice();
+        let front = new Array(), back = new Array();
+        for (let i = 0; i < polygons.length; i++) {
+            this.plane.splitPolygon(polygons[i], front, back, front, back);
+        }
+        if (this.front)
+            front = this.front.clipPolygons(front);
+        this.back ? (back = this.back.clipPolygons(back)) : (back = []);
+        return front.concat(back);
+    }
+    // Remove all polygons in this BSP tree that are inside the other BSP tree
+    // `bsp`.
+    clipTo(bsp) {
+        this.polygons = bsp.clipPolygons(this.polygons);
+        if (this.front)
+            this.front.clipTo(bsp);
+        if (this.back)
+            this.back.clipTo(bsp);
+    }
+    // Return a list of all polygons in this BSP tree.
+    allPolygons() {
+        let polygons = this.polygons.slice();
+        if (this.front)
+            polygons = polygons.concat(this.front.allPolygons());
+        if (this.back)
+            polygons = polygons.concat(this.back.allPolygons());
+        return polygons;
+    }
+    // Build a BSP tree out of `polygons`. When called on an existing tree, the
+    // new polygons are filtered down to the bottom of the tree and become new
+    // nodes there. Each set of polygons is partitioned using the first polygon
+    // (no heuristic is used to pick a good split).
+    build(polygons) {
+        if (!polygons.length)
+            return;
+        if (!this.plane)
+            this.plane = polygons[0].plane.clone();
+        const front = [], back = [];
+        for (let i = 0; i < polygons.length; i++) {
+            this.plane.splitPolygon(polygons[i], this.polygons, this.polygons, front, back);
+        }
+        if (front.length) {
+            if (!this.front)
+                this.front = new Node();
+            this.front.build(front);
+        }
+        if (back.length) {
+            if (!this.back)
+                this.back = new Node();
+            this.back.build(back);
+        }
+    }
+}

--- a/lib/csg/Plane.ts
+++ b/lib/csg/Plane.ts
@@ -1,0 +1,88 @@
+import { Polygon } from './Polygon';
+import { Vector } from './Vector';
+/**
+ * Represents a plane in 3D space.
+ */
+export class Plane {
+    constructor(normal, w) {
+        this.normal = normal;
+        this.w = w;
+        this.normal = normal;
+        this.w = w;
+    }
+    clone() {
+        return new Plane(this.normal.clone(), this.w);
+    }
+    flip() {
+        this.normal.negate();
+        this.w = -this.w;
+    }
+    // Split `polygon` by this plane if needed, then put the polygon or polygon
+    // fragments in the appropriate lists. Coplanar polygons go into either
+    // `coplanarFront` or `coplanarBack` depending on their orientation with
+    // respect to this plane. Polygons in front or in back of this plane go into
+    // either `front` or `back`.
+    splitPolygon(polygon, coplanarFront, coplanarBack, front, back) {
+        const COPLANAR = 0;
+        const FRONT = 1;
+        const BACK = 2;
+        const SPANNING = 3;
+        // Classify each point as well as the entire polygon into one of the above
+        // four classes.
+        let polygonType = 0;
+        const types = [];
+        for (let i = 0; i < polygon.vertices.length; i++) {
+            const t = this.normal.dot(polygon.vertices[i].pos) - this.w;
+            const type = t < -Plane.EPSILON ? BACK : t > Plane.EPSILON ? FRONT : COPLANAR;
+            polygonType |= type;
+            types.push(type);
+        }
+        // Put the polygon in the correct list, splitting it when necessary.
+        switch (polygonType) {
+            case COPLANAR:
+                (this.normal.dot(polygon.plane.normal) > 0
+                    ? coplanarFront
+                    : coplanarBack).push(polygon);
+                break;
+            case FRONT:
+                front.push(polygon);
+                break;
+            case BACK:
+                back.push(polygon);
+                break;
+            case SPANNING: {
+                const f = [], b = [];
+                for (let i = 0; i < polygon.vertices.length; i++) {
+                    const j = (i + 1) % polygon.vertices.length;
+                    const ti = types[i], tj = types[j];
+                    const vi = polygon.vertices[i], vj = polygon.vertices[j];
+                    if (ti != BACK)
+                        f.push(vi);
+                    if (ti != FRONT)
+                        b.push(ti != BACK ? vi.clone() : vi);
+                    if ((ti | tj) == SPANNING) {
+                        const t = (this.w - this.normal.dot(vi.pos)) /
+                            this.normal.dot(new Vector().copy(vj.pos).sub(vi.pos));
+                        const v = vi.interpolate(vj, t);
+                        f.push(v);
+                        b.push(v.clone());
+                    }
+                }
+                if (f.length >= 3)
+                    front.push(new Polygon(f, polygon.shared));
+                if (b.length >= 3)
+                    back.push(new Polygon(b, polygon.shared));
+                break;
+            }
+        }
+    }
+    static fromPoints(a, b, c) {
+        const n = new Vector()
+            .copy(b)
+            .sub(a)
+            .cross(new Vector().copy(c).sub(a))
+            .normalize();
+        return new Plane(n.clone(), n.dot(a));
+    }
+}
+Plane.EPSILON = 1e-5;

--- a/lib/csg/Polygon.ts
+++ b/lib/csg/Polygon.ts
@@ -1,0 +1,25 @@
+import { Plane } from './Plane';
+/**
+ * Represents a convex polygon. The vertices used to initialize a polygon must
+ * be coplanar and form a convex loop. They do not have to be `Vertex`
+ * instances but they must behave similarly (duck typing can be used for
+ * customization).
+ *
+ * Each convex polygon has a `shared` property, which is shared between all
+ * polygons that are clones of each other or were split from the same polygon.
+ * This can be used to define per-polygon properties (such as surface color).
+ */
+export class Polygon {
+    constructor(vertices, shared) {
+        this.vertices = vertices;
+        this.shared = shared;
+        this.plane = Plane.fromPoints(vertices[0].pos, vertices[1].pos, vertices[2].pos);
+    }
+    clone() {
+        return new Polygon(this.vertices.map((v) => v.clone()), this.shared);
+    }
+    flip() {
+        this.vertices.reverse().map((v) => v.flip());
+        this.plane.flip();
+    }
+}

--- a/lib/csg/Vector.ts
+++ b/lib/csg/Vector.ts
@@ -1,0 +1,77 @@
+import { Vector3 } from 'three';
+/**
+ * Represents a 3D vector.
+ */
+export class Vector {
+    constructor(x = 0, y = 0, z = 0) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+    copy(v) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        return this;
+    }
+    clone() {
+        return new Vector(this.x, this.y, this.z);
+    }
+    negate() {
+        this.x *= -1;
+        this.y *= -1;
+        this.z *= -1;
+        return this;
+    }
+    add(a) {
+        this.x += a.x;
+        this.y += a.y;
+        this.z += a.z;
+        return this;
+    }
+    sub(a) {
+        this.x -= a.x;
+        this.y -= a.y;
+        this.z -= a.z;
+        return this;
+    }
+    times(a) {
+        this.x *= a;
+        this.y *= a;
+        this.z *= a;
+        return this;
+    }
+    dividedBy(a) {
+        this.x /= a;
+        this.y /= a;
+        this.z /= a;
+        return this;
+    }
+    lerp(a, t) {
+        return this.add(new Vector().copy(a).sub(this).times(t));
+    }
+    unit() {
+        return this.dividedBy(this.length());
+    }
+    length() {
+        return Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2) + Math.pow(this.z, 2));
+    }
+    normalize() {
+        return this.unit();
+    }
+    cross(b) {
+        const a = this.clone();
+        const ax = a.x, ay = a.y, az = a.z;
+        const bx = b.x, by = b.y, bz = b.z;
+        this.x = ay * bz - az * by;
+        this.y = az * bx - ax * bz;
+        this.z = ax * by - ay * bx;
+        return this;
+    }
+    dot(b) {
+        return this.x * b.x + this.y * b.y + this.z * b.z;
+    }
+    toVector3() {
+        return new Vector3(this.x, this.y, this.z);
+    }
+}

--- a/lib/csg/Vertex.ts
+++ b/lib/csg/Vertex.ts
@@ -1,0 +1,33 @@
+import { Vector } from './Vector';
+/**
+ * Represents a vertex of a polygon. Use your own vertex class instead of this
+ * one to provide additional features like texture coordinates and vertex
+ * colors. Custom vertex classes need to provide a `pos` property and `clone()`,
+ * `flip()`, and `interpolate()` methods that behave analogous to the ones
+ * defined by `CSG.Vertex`. This class provides `normal` so convenience
+ * functions like `CSG.sphere()` can return a smooth vertex normal, but `normal`
+ * is not used anywhere else.
+ */
+export class Vertex {
+    constructor(pos, normal, uv, color) {
+        this.pos = new Vector().copy(pos);
+        this.normal = new Vector().copy(normal);
+        this.uv = new Vector().copy(uv);
+        this.uv.z = 0;
+        color && (this.color = new Vector().copy(color));
+    }
+    clone() {
+        return new Vertex(this.pos, this.normal, this.uv, this.color);
+    }
+    // Invert all orientation-specific data (e.g. vertex normal). Called when the
+    // orientation of a polygon is flipped.
+    flip() {
+        this.normal.negate();
+    }
+    // Create a new vertex between this vertex and `other` by linearly
+    // interpolating all properties using a parameter of `t`. Subclasses should
+    // override this to interpolate additional properties.
+    interpolate(other, t) {
+        return new Vertex(this.pos.clone().lerp(other.pos, t), this.normal.clone().lerp(other.normal, t), this.uv.clone().lerp(other.uv, t), this.color && other.color && this.color.clone().lerp(other.color, t));
+    }
+}

--- a/lib/csg/index.ts
+++ b/lib/csg/index.ts
@@ -1,0 +1,1 @@
+export * from './CSG';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@react-three/drei": "^10.3.0",
-        "@react-three/fiber": "^9.1.4",
+        "@react-three/drei": "^10.5.0",
+        "@react-three/fiber": "^9.2.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/react-dom": "^19.1.6",
-        "astro": "^5.10.1",
+        "astro": "^5.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
@@ -28,9 +28,8 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "three": "^0.177.0",
-        "three-bvh-csg": "^0.0.17",
         "three-stdlib": "^2.36.0",
-        "tw-animate-css": "^1.3.4"
+        "tw-animate-css": "^1.3.5"
       },
       "devDependencies": {
         "@types/react": "^19.1.8",
@@ -63,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.2.tgz",
-      "integrity": "sha512-bO35JbWpVvyKRl7cmSJD822e8YA8ThR/YbUsciWNA7yTcqpIAL2hJDToWP5KcZBWxGT6IOdOkHSXARSNZc4l/Q==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.3.tgz",
+      "integrity": "sha512-DDRtD1sPvAuA7ms2btc9A7/7DApKqgLMNrE6kh5tmkfy8utD0Z738gqd3p5aViYYdUtHIyEJ1X4mCMxfCfu15w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.6.1",
@@ -83,7 +82,7 @@
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
         "shiki": "^3.2.1",
-        "smol-toml": "^1.3.1",
+        "smol-toml": "^1.3.4",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
@@ -2051,16 +2050,16 @@
       "license": "MIT"
     },
     "node_modules/@react-three/drei": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.3.0.tgz",
-      "integrity": "sha512-+4NHCAUI38jp8XlbuKKWl/23y3F/JKdkvnYsrVXxhw150OyWKJoft+Yyd7dl6awxfV/Gn08x3R9pRRFUuDQwDA==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.5.1.tgz",
+      "integrity": "sha512-ixEU41HC64adcZQV2tCIHKTFxT/HRSu3QgZrDqBeQNyNou6FYgoM2sIxujgKYGWf4bVkN5A+OBGnr8/CzVVhrQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mediapipe/tasks-vision": "0.10.17",
         "@monogrid/gainmap-js": "^3.0.6",
         "@use-gesture/react": "^10.3.1",
-        "camera-controls": "^2.9.0",
+        "camera-controls": "^3.0.0",
         "cross-env": "^7.0.3",
         "detect-gpu": "^5.0.56",
         "glsl-noise": "^0.0.0",
@@ -2091,9 +2090,9 @@
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.1.4.tgz",
-      "integrity": "sha512-Ugzs6n6YNORSa4hRZH1CKTd5DLTzwOvYjze+EZWS8iVDyeNQETnLzuke+MMEuXTqM8eAV/gyWgd27t/GR41oGA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.2.0.tgz",
+      "integrity": "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -2441,60 +2440,60 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-AG8vnSi1W2pbgR2B911EfGqtLE9c4hQBYkv/x7Z+Kt0VxhgQKcW7UNDVYsu9YxwV6u+OJrvdJrMq6DNWoBjihQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.2.tgz",
-      "integrity": "sha512-1/adJbSMBOkpScCE/SB6XkjJU17ANln3Wky7lOmrnpl+zBdQ1qXUJg2GXTYVHRq+2j3hd1DesmElTXYDgtfSOQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.8.1.tgz",
+      "integrity": "sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
-      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.8.1.tgz",
+      "integrity": "sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
-      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.8.1.tgz",
+      "integrity": "sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
-      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.8.1.tgz",
+      "integrity": "sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -3168,14 +3167,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.10.1.tgz",
-      "integrity": "sha512-DJVmt+51jU1xmgmAHCDwuUgcG/5aVFSU+tcX694acAZqPVt8EMUAmUZcJDX36Z7/EztnPph9HR3pm72jS2EgHQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.0.tgz",
+      "integrity": "sha512-Oov5JsMFHuUmuO+Nx6plfv3nQNK1Xl/8CgLvR8lBhZTjYnraxhuPX5COVAzbom+YLgwaDfK7KBd8zOEopRf9mg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/markdown-remark": "6.3.2",
+        "@astrojs/markdown-remark": "6.3.3",
         "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^2.4.0",
         "@oslojs/encoding": "^1.1.0",
@@ -3218,6 +3217,7 @@
         "rehype": "^13.0.2",
         "semver": "^7.7.1",
         "shiki": "^3.2.1",
+        "smol-toml": "^1.3.4",
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.12",
         "tsconfck": "^3.1.5",
@@ -3425,10 +3425,14 @@
       }
     },
     "node_modules/camera-controls": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
-      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
+      "integrity": "sha512-w5oULNpijgTRH0ARFJJ0R5ct1nUM3R3WP7/b8A6j9uTGpRfnsypc/RBMPQV8JQDPayUe37p/TZZY1PcUr4czOQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0",
+        "npm": ">=10.8.2"
+      },
       "peerDependencies": {
         "three": ">=0.126.1"
       }
@@ -3767,9 +3771,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
-      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -6575,17 +6579,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.2.tgz",
-      "integrity": "sha512-wuxzZzQG8kvZndD7nustrNFIKYJ1jJoWIPaBpVe2+KHSvtzMi4SBjOxrigs8qeqce/l3U0cwiC+VAkLKSunHQQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.8.1.tgz",
+      "integrity": "sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.2",
-        "@shikijs/engine-javascript": "3.4.2",
-        "@shikijs/engine-oniguruma": "3.4.2",
-        "@shikijs/langs": "3.4.2",
-        "@shikijs/themes": "3.4.2",
-        "@shikijs/types": "3.4.2",
+        "@shikijs/core": "3.8.1",
+        "@shikijs/engine-javascript": "3.8.1",
+        "@shikijs/engine-oniguruma": "3.8.1",
+        "@shikijs/langs": "3.8.1",
+        "@shikijs/themes": "3.8.1",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -6607,9 +6611,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
-      "integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
+      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -6765,16 +6769,6 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
       "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
       "license": "MIT"
-    },
-    "node_modules/three-bvh-csg": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/three-bvh-csg/-/three-bvh-csg-0.0.17.tgz",
-      "integrity": "sha512-iEkHDF8GRfGM6593Cuw8SnF1vfENCp46gIAtRzuL4nGXGWPcR1sbTBwM9ptDONb5twqlZp5WkAKya5aBKe2qcA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "three": ">=0.151.0",
-        "three-mesh-bvh": ">=0.6.6"
-      }
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -6956,9 +6950,9 @@
       }
     },
     "node_modules/tw-animate-css": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.4.tgz",
-      "integrity": "sha512-dd1Ht6/YQHcNbq0znIT6dG8uhO7Ce+VIIhZUhjsryXsMPJQz3bZg7Q2eNzLwipb25bRZslGb2myio5mScd1TFg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.5.tgz",
+      "integrity": "sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
     "three": "^0.177.0",
-    "three-bvh-csg": "^0.0.17",
     "three-stdlib": "^2.36.0",
     "tw-animate-css": "^1.3.5"
   },

--- a/src/models/wavy/bottom.tsx
+++ b/src/models/wavy/bottom.tsx
@@ -6,7 +6,7 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import * as React from "react";
 import * as THREE from "three";
-import { ADDITION, Brush, Evaluator, SUBTRACTION } from "three-bvh-csg";
+import { CSG } from "@lib/csg";
 import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { Button } from "@/components/ui/button";
 import { wavyProperties, type WavyProperties } from "@/utils/properties";
@@ -90,33 +90,32 @@ export default function WavyBottom() {
 }
 
 function getBottomGeometry(radius: number, waveDensity: number, height: number, twistRatio: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
-    const bodyGeometry = createWavyGeometry(radius, 0.4, waveDensity, height, .1 * twistRatio, 1024, true);
-    const bodyBrush = new Brush(bodyGeometry);
+    const bodyMesh = new THREE.Mesh(createWavyGeometry(radius, 0.4, waveDensity, height, .1 * twistRatio, 1024, true));
 
     const floorGeometry = new THREE.CylinderGeometry(radius - 3, radius - 3, 4, 32);
     floorGeometry.translate(0, 2, 0);
-    const floorBrush = new Brush(floorGeometry);
+    const floorMesh = new THREE.Mesh(floorGeometry);
 
     const waterHoleGeometry = new THREE.BoxGeometry(20, 10, 20);
     waterHoleGeometry.translate(radius - 5, height, 0);
-    const waterHoleBrush = new Brush(waterHoleGeometry);
+    const waterHoleMesh = new THREE.Mesh(waterHoleGeometry);
 
     const waterEntryGeometry = new THREE.BoxGeometry(25, 7.5, 25);
     waterEntryGeometry.translate(radius - 5, height - 3.7, 0);
-    const waterEntryBrush = new Brush(waterEntryGeometry);
+    const waterEntryMesh = new THREE.Mesh(waterEntryGeometry);
 
     const cylinderHoleGeometry = new THREE.CylinderGeometry(radius - 3, radius - 3, height, 32);
     cylinderHoleGeometry.translate(0, (height / 2) + 4, 0);
-    const cylinderHoleBrush = new Brush(cylinderHoleGeometry);
+    const cylinderHoleMesh = new THREE.Mesh(cylinderHoleGeometry);
 
-    const evaluator = new Evaluator();
-    let result = evaluator.evaluate(bodyBrush, floorBrush, ADDITION);
-    result = evaluator.evaluate(result, waterEntryBrush, ADDITION);
-    result = evaluator.evaluate(result, waterHoleBrush, SUBTRACTION);
-    result = evaluator.evaluate(result, cylinderHoleBrush, SUBTRACTION);
-    result.geometry = mergeVertices(result.geometry, 1e-5);
-    result.geometry.deleteAttribute('normal');
-    result.geometry.computeVertexNormals();
+    let resultMesh = CSG.union(bodyMesh, floorMesh);
+    resultMesh = CSG.union(resultMesh, waterEntryMesh);
+    resultMesh = CSG.subtract(resultMesh, waterHoleMesh);
+    resultMesh = CSG.subtract(resultMesh, cylinderHoleMesh);
 
-    return result.geometry;
+    const geometry = mergeVertices(resultMesh.geometry, 1e-5);
+    geometry.deleteAttribute('normal');
+    geometry.computeVertexNormals();
+
+    return geometry;
 }

--- a/src/models/wavy/connector.tsx
+++ b/src/models/wavy/connector.tsx
@@ -6,7 +6,8 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import * as React from "react";
 import * as THREE from "three";
-import { ADDITION, Brush, Evaluator, SUBTRACTION } from "three-bvh-csg";
+import { CSG } from "@lib/csg";
+import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { Button } from "@/components/ui/button";
 import { wavyProperties, type WavyProperties } from "@/utils/properties";
 import { Label } from "@radix-ui/react-dropdown-menu";
@@ -74,52 +75,52 @@ export default function WavyConnector() {
 }
 
 function getConnectorGeometry(height: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
-    const bodyGeometry = new THREE.CylinderGeometry(8, 8, height, 32);
-    bodyGeometry.translate(0, 0, 0);
-    const bodyBrush = new Brush(bodyGeometry);
+    const bodyMesh = new THREE.Mesh(new THREE.CylinderGeometry(8, 8, height, 32));
 
     const headGeometry = new THREE.CylinderGeometry(10, 10, 2, 32);
     headGeometry.translate(0, height / 2, 0);
-    const headBrush = new Brush(headGeometry);
+    const headMesh = new THREE.Mesh(headGeometry);
 
     const mainHoleGeometry = new THREE.CylinderGeometry(6, 6, height, 32);
     mainHoleGeometry.translate(0, 2, 0);
-    const mainHoleBrush = new Brush(mainHoleGeometry);
+    const mainHoleMesh = new THREE.Mesh(mainHoleGeometry);
 
-    const evaluator = new Evaluator();
-    let result = evaluator.evaluate(bodyBrush, headBrush, ADDITION);
-    result = evaluator.evaluate(result, mainHoleBrush, SUBTRACTION);
+    let resultMesh = CSG.union(bodyMesh, headMesh);
+    resultMesh = CSG.subtract(resultMesh, mainHoleMesh);
 
     const points = getPointsOnCircle(7, 4);
 
     const miniBottomHoleGeometry = new THREE.CylinderGeometry(1.5, 1.5, 2, 32);
     for (let index = 0; index < points.length; index++) {
-        const tempMiniBottomHoleGeometry = miniBottomHoleGeometry.clone();
-        const miniBottomHoleBrush = new Brush(tempMiniBottomHoleGeometry);
-        miniBottomHoleBrush.position.set(points[index].x, -height / 2 + 1, points[index].z);
-        miniBottomHoleBrush.updateMatrixWorld(true);
-        result = evaluator.evaluate(result, miniBottomHoleBrush, SUBTRACTION);
+        const tempHoleMesh = new THREE.Mesh(miniBottomHoleGeometry.clone());
+        tempHoleMesh.position.set(points[index].x, -height / 2 + 1, points[index].z);
+        tempHoleMesh.updateMatrix();
+        resultMesh = CSG.subtract(resultMesh, tempHoleMesh);
     }
 
-    const sideHolesBrush = getMeshBrush(evaluator, height - 10);
-    result = evaluator.evaluate(result, sideHolesBrush, SUBTRACTION);
+    const sideHolesMesh = getCapsuleMesh(height - 10);
+    resultMesh = CSG.subtract(resultMesh, sideHolesMesh);
 
-    return result.geometry;
+    const geometry = mergeVertices(resultMesh.geometry, 1e-5);
+    geometry.deleteAttribute('normal');
+    geometry.computeVertexNormals();
+
+    return geometry;
 }
 
-function getMeshBrush(evaluator: Evaluator, height: number): Brush {
+function getCapsuleMesh(height: number): THREE.Mesh {
     const capsuleHoleGeometry = new THREE.BoxGeometry(2, 20, height);
-    let capsuleHoleBrush01 = new Brush(capsuleHoleGeometry);
-    capsuleHoleBrush01.rotateX(Math.PI / 2);
-    capsuleHoleBrush01.updateMatrixWorld(true);
-    const capsuleHoleBrush02 = capsuleHoleBrush01.clone();
-    capsuleHoleBrush02.rotateZ(Math.PI / 2);
-    capsuleHoleBrush02.updateMatrixWorld(true);
-    capsuleHoleBrush01 = evaluator.evaluate(capsuleHoleBrush01, capsuleHoleBrush02, ADDITION);
+    const capsuleHoleMesh01 = new THREE.Mesh(capsuleHoleGeometry);
+    capsuleHoleMesh01.rotateX(Math.PI / 2);
+    capsuleHoleMesh01.updateMatrix();
+    const capsuleHoleMesh02 = capsuleHoleMesh01.clone();
+    capsuleHoleMesh02.rotateZ(Math.PI / 2);
+    capsuleHoleMesh02.updateMatrix();
+    let capsuleMesh = CSG.union(capsuleHoleMesh01, capsuleHoleMesh02);
 
-    const capsuleHoleBrush03 = capsuleHoleBrush01.clone();
-    capsuleHoleBrush03.rotateY(Math.PI / 4);
-    capsuleHoleBrush03.updateMatrixWorld(true);
-    capsuleHoleBrush01 = evaluator.evaluate(capsuleHoleBrush01, capsuleHoleBrush03, ADDITION);
-    return capsuleHoleBrush01;
+    const capsuleHoleMesh03 = capsuleMesh.clone();
+    capsuleHoleMesh03.rotateY(Math.PI / 4);
+    capsuleHoleMesh03.updateMatrix();
+    capsuleMesh = CSG.union(capsuleMesh, capsuleHoleMesh03);
+    return capsuleMesh;
 }

--- a/src/models/wavy/top.tsx
+++ b/src/models/wavy/top.tsx
@@ -7,7 +7,7 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import * as React from "react";
 import * as THREE from "three";
-import { ADDITION, Brush, Evaluator, SUBTRACTION } from "three-bvh-csg";
+import { CSG } from "@lib/csg";
 import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { Button } from "@/components/ui/button";
 import { wavyProperties, type WavyProperties } from "@/utils/properties";
@@ -91,19 +91,18 @@ export default function WavyTop() {
 }
 
 function getTopGeometry(radius: number, waveDensity: number, height: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
-    const bodyGeometry = createWavyGeometry(radius, 0.4, waveDensity, height, .1, 1024, false);
-    const bodyBrush = new Brush(bodyGeometry);
+    const bodyMesh = new THREE.Mesh(createWavyGeometry(radius, 0.4, waveDensity, height, .1, 1024, false));
 
     const floorGeometry = new THREE.CylinderGeometry(radius - 3, radius - 3, 4, 32);
-    const floorBrush = new Brush(floorGeometry);
+    const floorMesh = new THREE.Mesh(floorGeometry);
 
     const waterHoleTopGeometry = new THREE.CylinderGeometry(10, 10, 2);
     waterHoleTopGeometry.translate(0, 1, 0);
-    const waterHoleTopBrush = new Brush(waterHoleTopGeometry);
+    const waterHoleTopMesh = new THREE.Mesh(waterHoleTopGeometry);
 
     const waterHoleBottomGeometry = new THREE.CylinderGeometry(8, 8, 2);
     waterHoleBottomGeometry.translate(0, -1, 0);
-    const waterHoleBottomBrush = new Brush(waterHoleBottomGeometry);
+    const waterHoleBottomMesh = new THREE.Mesh(waterHoleBottomGeometry);
 
     let holeCount = 1;
     switch (true) {
@@ -115,28 +114,26 @@ function getTopGeometry(radius: number, waveDensity: number, height: number): TH
             break;
     }
 
-    const evaluator = new Evaluator()
-    let result = evaluator.evaluate(bodyBrush, floorBrush, ADDITION);
+    let resultMesh = CSG.union(bodyMesh, floorMesh);
 
-    const waterHoleResult = evaluator.evaluate(waterHoleTopBrush, waterHoleBottomBrush, ADDITION);
+    const waterHoleResult = CSG.union(waterHoleTopMesh, waterHoleBottomMesh);
     if (holeCount == 1) {
-        result = evaluator.evaluate(result, waterHoleResult, SUBTRACTION);
+        resultMesh = CSG.subtract(resultMesh, waterHoleResult);
     } else {
         const points = getPointsOnCircle(radius, holeCount);
         for (let index = 0; index < points.length; index++) {
             const point = points[index];
-            const waterHoleBrush = waterHoleResult.clone();
-            waterHoleBrush.translateX(point.x);
-            waterHoleBrush.translateZ(point.z);
-            waterHoleBrush.updateMatrixWorld(true);
-            result = evaluator.evaluate(result, waterHoleBrush, SUBTRACTION);
+            const waterHoleMesh = waterHoleResult.clone();
+            waterHoleMesh.position.set(point.x, 0, point.z);
+            waterHoleMesh.updateMatrix();
+            resultMesh = CSG.subtract(resultMesh, waterHoleMesh);
         }
     }
 
 
-    result.geometry = mergeVertices(result.geometry, 1e-5);
-    result.geometry.deleteAttribute('normal');
-    result.geometry.computeVertexNormals();
+    const geometry = mergeVertices(resultMesh.geometry, 1e-5);
+    geometry.deleteAttribute('normal');
+    geometry.computeVertexNormals();
 
-    return result.geometry;
+    return geometry;
 }


### PR DESCRIPTION
## Summary
- drop `three-bvh-csg` dependency and install a small internal CSG helper
- import the new CSG helper in wavy models and replace subtraction/merge logic
- vendor the `three-csg-ts` code under `lib/csg`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879fc79b5d48323aa731aa18e5998c2