### PR TITLE
Make geometry generators async

### DIFF
--- a/src/models/wavy/bottom.tsx
+++ b/src/models/wavy/bottom.tsx
@@ -25,6 +25,19 @@ export default function WavyBottom() {
     }, [properties]);
 
     const meshRef = React.useRef<THREE.Mesh>(null!);
+    const [geometry, setGeometry] = React.useState<THREE.BufferGeometry>();
+
+    React.useEffect(() => {
+        (async () => {
+            const geom = await getBottomGeometry(
+                properties.radius,
+                properties.waveDensity,
+                properties.bottomHeight,
+                properties.bottomHeight / properties.topHeight,
+            );
+            setGeometry(geom);
+        })();
+    }, [properties.radius, properties.waveDensity, properties.bottomHeight, properties.topHeight]);
     return (
         <AppLayout>
             <SidebarProvider>
@@ -71,7 +84,7 @@ export default function WavyBottom() {
                             <group>
                                 <mesh
                                     ref={meshRef}
-                                    geometry={getBottomGeometry(properties.radius, properties.waveDensity, properties.bottomHeight, (properties.bottomHeight / properties.topHeight))}
+                                    geometry={geometry}
                                     material={getGlobalMaterial(properties.color)} />
                             </group>
                             <OrbitControls />
@@ -83,7 +96,12 @@ export default function WavyBottom() {
     )
 }
 
-function getBottomGeometry(radius: number, waveDensity: number, height: number, twistRatio: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
+async function getBottomGeometry(
+    radius: number,
+    waveDensity: number,
+    height: number,
+    twistRatio: number,
+): Promise<THREE.BufferGeometry<THREE.NormalBufferAttributes>> {
     const bodyGeometry = createWavyGeometry(radius, 0.4, waveDensity, height, .1 * twistRatio, 1024, true);
     const bodyBrush = new Brush(bodyGeometry);
 

--- a/src/models/wavy/connector.tsx
+++ b/src/models/wavy/connector.tsx
@@ -24,6 +24,14 @@ export default function WavyConnector() {
     }, [properties]);
 
     const meshRef = React.useRef<THREE.Mesh>(null!);
+    const [geometry, setGeometry] = React.useState<THREE.BufferGeometry>();
+
+    React.useEffect(() => {
+        (async () => {
+            const geom = await getConnectorGeometry(properties.bottomHeight - 5);
+            setGeometry(geom);
+        })();
+    }, [properties.bottomHeight]);
     return (
         <AppLayout>
             <SidebarProvider>
@@ -54,7 +62,7 @@ export default function WavyConnector() {
                             <group>
                                 <mesh
                                     ref={meshRef}
-                                    geometry={getConnectorGeometry(properties.bottomHeight - 5)}
+                                    geometry={geometry}
                                     material={getGlobalMaterial(properties.color)}
                                     position={[0, (properties.bottomHeight - 5) / 2, 0]} />
                             </group>
@@ -67,7 +75,7 @@ export default function WavyConnector() {
     )
 }
 
-function getConnectorGeometry(height: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
+async function getConnectorGeometry(height: number): Promise<THREE.BufferGeometry<THREE.NormalBufferAttributes>> {
     const bodyGeometry = new THREE.CylinderGeometry(8, 8, height, 32);
     bodyGeometry.translate(0, 0, 0);
     const bodyBrush = new Brush(bodyGeometry);

--- a/src/models/wavy/top.tsx
+++ b/src/models/wavy/top.tsx
@@ -26,6 +26,18 @@ export default function WavyTop() {
     }, [properties]);
 
     const meshRef = React.useRef<THREE.Mesh>(null!);
+    const [geometry, setGeometry] = React.useState<THREE.BufferGeometry>();
+
+    React.useEffect(() => {
+        (async () => {
+            const geom = await getTopGeometry(
+                properties.radius,
+                properties.waveDensity,
+                properties.topHeight,
+            );
+            setGeometry(geom);
+        })();
+    }, [properties.radius, properties.waveDensity, properties.topHeight]);
     return (
         <AppLayout>
             <SidebarProvider>
@@ -72,7 +84,7 @@ export default function WavyTop() {
                             <group>
                                 <mesh
                                     ref={meshRef}
-                                    geometry={getTopGeometry(properties.radius, properties.waveDensity, properties.topHeight)}
+                                    geometry={geometry}
                                     material={getGlobalMaterial(properties.color)} />
                             </group>
                             <OrbitControls />
@@ -84,7 +96,11 @@ export default function WavyTop() {
     )
 }
 
-function getTopGeometry(radius: number, waveDensity: number, height: number): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
+async function getTopGeometry(
+    radius: number,
+    waveDensity: number,
+    height: number,
+): Promise<THREE.BufferGeometry<THREE.NormalBufferAttributes>> {
     const bodyGeometry = createWavyGeometry(radius, 0.4, waveDensity, height, .1, 1024, false);
     const bodyBrush = new Brush(bodyGeometry);
     const evaluator = new Evaluator()


### PR DESCRIPTION
## Summary
- refactor geometry generation in wavy models to async functions
- compute meshes asynchronously within React components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68876ebbd9d48323b7ca24af206b9c19