### PR TITLE
Fix SSR import of replicad worker

### DIFF
--- a/src/models/wavy/replicad.tsx
+++ b/src/models/wavy/replicad.tsx
@@ -1,6 +1,5 @@
 import { SidebarProvider } from "@/components/ui/sidebar";
 import AppLayout from "@/layouts/appLayout";
-import { createMesh } from "@/utils/worker";
 import { OrbitControls } from "@react-three/drei";
 import { Canvas, useThree } from "@react-three/fiber";
 import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
@@ -42,7 +41,9 @@ export default function WavyReplicad() {
   const [mesh, setMesh] = useState<any>(null);
 
   useEffect(() => {
-    createMesh().then((m) => setMesh(m));
+    import("@/utils/worker").then(({ createMesh }) => {
+      createMesh().then((m) => setMesh(m));
+    });
   }, []);
 
   const faces = mesh?.faces;


### PR DESCRIPTION
## Summary
- load `createMesh` lazily on the client
- dynamically import replicad's WASM loader in `worker.ts`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888d7e8d940832382bb7b89e119770b